### PR TITLE
Add quick reference for common problems

### DIFF
--- a/cookbook.md
+++ b/cookbook.md
@@ -35,3 +35,49 @@ change: missing file etc. By adding non-solvable constraint, we tell Cabal to
 never pick this version.
 
 ----
+
+**Problem:**
+
+Several different errors: Missing modules or identifiers, name clashes.
+This is a quick reference for adding bounds for common errors.
+
+**Fix:** If the identifier is missing add the constraint on the RHS.
+
+```
+base upper bounds:
+Illegal bang-pattern (use -XBangP..)        => base < 4.4
+Prelude.foldr                               => base < 4.5
+Prelude.catch                               => base < 4.6
+
+base lower bounds:
+Data.Monoid.<>                              => base >= 4.5
+Data.Bits.zeroBits                          => base >= 4.7
+Prelude.&                                   => base >= 4.8
+Control.Concurrent.forkFinally              => base >= 4.6
+
+bytestring:
+Data.ByteString.Builder                     => bytestring >= 0.10.2
+Data.ByteString.Lazy.Builder                => bytestring >= 0.10
+Data.ByteString.Lazy.toStrict               => bytestring >= 0.10
+
+containers:
+Data.IntMap.Strict                          => containers >= 0.5
+Data.Map.Strict                             => containers >= 0.5
+
+getModificationTime :: _ -> IO UTCTime      => directory >= 1.2
+
+Attoparsec.Done/Fail/Partial                => attoparsec < 0.10
+Scientific vs Number                        => aeson < 0.7
+
+Control.Monad.Trans.Resource & conduit      => conduit < 0.3
+
+MonadThrow.monadThrow doesn't exist         => exceptions < 0.4, resourcet < 1.1
+
+crypto packages:
+Crypto.Cipher.AES & depends on cryptocipher => cryptocipher < 0.5
+Crypto.Cipher.RSA & depends on cryptocipher => cryptocipher < 0.5
+Crypto.Cipher.AES.Key/keyOfCtx              => cipher-aes < 0.2
+Crypto.Modes.IV                             => crypto-api < 0.11
+Crypto.Random.AESCtr.genRandomBytes         => cprng-aes < 0.5
+Couldn't match `Int' with `AESRNG'          => cprng-aes < 0.3
+```


### PR DESCRIPTION
This doesn't contain explanations, but could be added with links to haddocks, hdiff, or similar. It should be straight forward, I think. If the identifier is missing or clashes, add the given dependency.
